### PR TITLE
Fix LCC linker warning on mymemcpy

### DIFF
--- a/snprintf.c
+++ b/snprintf.c
@@ -1469,7 +1469,7 @@ mypow10(int exponent)
 
 #if !HAVE_VASPRINTF
 #if NEED_MYMEMCPY
-void *
+static void *
 mymemcpy(void *dst, void *src, size_t len)
 {
 	const char *from = src;


### PR DESCRIPTION
`Warning snprintf.c: 1472  inconsistent linkage for `mymemcpy' previously declared at snprintf.c 318`