### PR TITLE
conditionally set function name definitions

### DIFF
--- a/snprintf.c
+++ b/snprintf.c
@@ -271,10 +271,6 @@
 #define HAVE___VA_COPY 1
 #endif	/* !defined(HAVE___VA_COPY) */
 #endif	/* HAVE_CONFIG_H */
-#define snprintf rpl_snprintf
-#define vsnprintf rpl_vsnprintf
-#define asprintf rpl_asprintf
-#define vasprintf rpl_vasprintf
 #endif	/* TEST_SNPRINTF */
 
 #if !HAVE_SNPRINTF || !HAVE_VSNPRINTF || !HAVE_ASPRINTF || !HAVE_VASPRINTF
@@ -296,6 +292,7 @@
 #endif	/* HAVE_STDARG_H */
 
 #if !HAVE_VASPRINTF
+#define vasprintf rpl_vasprintf
 #if HAVE_STDLIB_H
 #include <stdlib.h>	/* For malloc(3). */
 #endif	/* HAVE_STDLIB_H */
@@ -320,6 +317,7 @@ static void *mymemcpy(void *, void *, size_t);
 #endif	/* !HAVE_VASPRINTF */
 
 #if !HAVE_VSNPRINTF
+#define vsnprintf rpl_vsnprintf
 #include <errno.h>	/* For ERANGE and errno. */
 #include <limits.h>	/* For *_MAX. */
 #if HAVE_FLOAT_H
@@ -337,6 +335,14 @@ static void *mymemcpy(void *, void *, size_t);
 #if HAVE_STDINT_H
 #include <stdint.h>	/* For intmax_t. */
 #endif	/* HAVE_STDINT_H */
+
+#if !HAVE_ASPRINTF
+#define asprintf rpl_asprintf
+#endif	/* !HAVE_ASPRINTF */
+
+#if !HAVE_SNPRINTF
+#define snprintf rpl_snprintf
+#endif	/* !HAVE_SNPRINTF */
 
 /* Support for unsigned long long int.  We may also need ULLONG_MAX. */
 #ifndef ULONG_MAX	/* We may need ULONG_MAX as a fallback. */


### PR DESCRIPTION
Hi Holger,

Thank you for the nice effort on c99-snprintf, it is really helpful.

I found something interesting that you may like, if you try these commands below with latest version of snprintf.c and the linked config.h (very simple, below), the second will fail with implicit declaration of vsnprintf and vasprintf, I guess thats because these are not included in c89 standard, that was with gcc v4.8.5.

gcc -I. -DHAVE_CONFIG_H -DTEST_SNPRINTF -Wall -Werror -std=c89 -c -o snprintf.o snprintf.c

gcc -I. -DHAVE_CONFIG_H -Wall -Werror -std=c89 -c -o snprintf.o snprintf.c

The fix was rather simple, just move the defines to where their presence is tested.

Hope I am not missing something and you like it, thanks again,

- [config.h](https://gist.github.com/ctarbide/1c29112c9135b740e95a016c8e854c15)

--ctarbide
